### PR TITLE
replaces deprecated set-value command

### DIFF
--- a/harvester/test_utils.py
+++ b/harvester/test_utils.py
@@ -69,7 +69,7 @@ def test_write_df_to_json(path_fixture, dataframe_fixture):
     assert not json_path.parent.exists()
 
 
-def write_df_to_json_handles_KeyError(path_fixture, dataframe_fixture):
+def test_write_df_to_json_handles_KeyError(path_fixture, dataframe_fixture):
     json_path = path_fixture
     min_json_path = Path(str(path_fixture)+".min.json")
     create_folder(json_path)

--- a/harvester/test_utils.py
+++ b/harvester/test_utils.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import os
 
 import pandas as pd
 import geopandas as gpd
@@ -66,3 +67,14 @@ def test_write_df_to_json(path_fixture, dataframe_fixture):
     min_json_path.unlink()
     json_path.parent.rmdir()
     assert not json_path.parent.exists()
+
+
+def write_df_to_json_handles_KeyError(path_fixture, dataframe_fixture):
+    json_path = path_fixture
+    min_json_path = Path(str(path_fixture)+".min.json")
+    create_folder(json_path)
+    del os.environ["GITHUB_OUTPUT"]
+    write_df_to_json(dataframe_fixture, str(json_path))
+    json_path.unlink()
+    min_json_path.unlink()
+    json_path.parent.rmdir()

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -24,7 +24,7 @@ def write_df_to_json(cleaned_gdf, outpath):
     minified = open(outpath + ".min.json", "w+")
     minified.write(json.dumps(json.loads(geojson), separators=(",", ":")))
     minified.close()
-    print("::set-output name=file::" + outpath)
+    print("file=" + outpath + " >> $GITHUB_OUTPUT")
 
 
 def get_overpass_gdf(json):

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import pandas as pd
 import geopandas as gp
@@ -24,7 +25,8 @@ def write_df_to_json(cleaned_gdf, outpath):
     minified = open(outpath + ".min.json", "w+")
     minified.write(json.dumps(json.loads(geojson), separators=(",", ":")))
     minified.close()
-    print("file=" + outpath + " >> $GITHUB_OUTPUT")
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+        print(f'file={outpath}', file=fh)
 
 
 def get_overpass_gdf(json):

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -25,8 +25,13 @@ def write_df_to_json(cleaned_gdf, outpath):
     minified = open(outpath + ".min.json", "w+")
     minified.write(json.dumps(json.loads(geojson), separators=(",", ":")))
     minified.close()
-    with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-        print(f'file={outpath}', file=fh)
+
+    try:
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print(f'file={outpath}', file=fh)
+    except (KeyError):
+        # not executed on a github CI runner; ignore this error when executed locally
+        pass
 
 
 def get_overpass_gdf(json):


### PR DESCRIPTION
Github announced deprecation of set-output and save-state commands in Github Actions.
Here the used set-output command is replaced as suggested in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Solves #41 